### PR TITLE
feat: 增加发送邮件域名白名单sendmail_whitelist #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ## 配置
 插件上架时，需要配置蓝鲸ESB相关参数，路径：设置->私有配置
+- sendmail_whitelist : 配置允许发送的域名白名单，多个域名用;号分隔, 输入*或不配置本项表示全开放, 每个邮箱域名格式为 @xxx.yyy 例如 @gmail.com
 - bk_app_code: ESB appcode // 如bk_ci等已在蓝鲸内注册的app
 - bk_app_secret: ESB appsecret // 对应app的密钥
 - bk_host: ESB host // 当前环境蓝鲸域名
@@ -20,3 +21,9 @@ fix: 敏感信息修复 #27
 
 ### v1.0.4
 fix: 某些网络情况下会导致发送卡住 #30
+
+### v1.1.0
+
+feat: 增加发送邮件域名白名单sendmail_whitelist #32
+
+- 增加sendmail_whitelist 私有配置，用于配置允许发送的域名白名单，多个用;号分隔，输入*表示全开放, 每个邮箱域名格式为 @xxx.yyy，例如@gmail.com

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tencent.bk.devops.atom</groupId>
     <artifactId>sendEmail</artifactId>
-    <version>1.0.4</version>
+    <version>1.1.0</version>
 
     <properties>
         <kotlin.version>1.3.30</kotlin.version>
         <!-- 引用的sdk版本，当sdk版本有升级时再修改 -->
-        <sdk.version>1.1.2</sdk.version>
+        <sdk.version>1.1.7</sdk.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/src/main/java/com/tencent/bk/devops/atom/task/BkSendEmailAtom.java
+++ b/src/main/java/com/tencent/bk/devops/atom/task/BkSendEmailAtom.java
@@ -76,43 +76,44 @@ public class BkSendEmailAtom implements TaskAtom<EmailParam> {
 
     private void checkParam(EmailParam param, AtomResult result) {
         Map<String, String> bkSensitiveConfInfo = param.getBkSensitiveConfInfo();
-        StringBuilder builder = new StringBuilder();
+        StringBuilder errorMessage = new StringBuilder();
         if (StringUtils.isBlank(bkSensitiveConfInfo.get(BK_APP_CODE))) {
-            builder.append("bk_app_code cannot be empty | ");
+            errorMessage.append("bk_app_code cannot be empty | ");
         }
         if (StringUtils.isBlank(bkSensitiveConfInfo.get(BK_APP_SECRET))) {
-            builder.append("bk_app_secret cannot be empty | ");
+            errorMessage.append("bk_app_secret cannot be empty | ");
         }
         if (StringUtils.isBlank(bkSensitiveConfInfo.get(BK_HOST))) {
-            builder.append("bk_host cannot be empty | ");
+            errorMessage.append("bk_host cannot be empty | ");
         }
         if (StringUtils.isBlank(bkSensitiveConfInfo.get(BK_TOKEN))
                 && StringUtils.isBlank(bkSensitiveConfInfo.get(BK_USERNAME))) {
-            builder.append("bk_token or bk_username cannot be empty | ");
+            errorMessage.append("bk_token or bk_username cannot be empty | ");
         }
-        if (StringUtils.isBlank(param.getReceivers())) {
-            builder.append("receiver cannot be empty ");
-        }
+
+        NotifyUtils.checkReceivers(param, errorMessage);
+
         if (StringUtils.equals(param.getBodyFormat(), HTML_FORMAT)) {
             if (StringUtils.isBlank(param.getContentPath())) {
-                builder.append("contextPath cannot be empty");
+                errorMessage.append("contextPath cannot be empty");
             } else {
                 File contentFile = new File(param.getBkWorkspace(), param.getContentPath());
                 if (!contentFile.exists()) {
-                    builder.append("content file:[").append(contentFile).append("] does not exist | ");
+                    errorMessage.append("content file:[").append(contentFile).append("] does not exist | ");
                 }
                 if (!contentFile.isFile()) {
-                    builder.append("content file:[").append(contentFile).append("] must be a file |");
+                    errorMessage.append("content file:[").append(contentFile).append("] must be a file |");
                 }
                 if (contentFile.length() > MAX_CONTEXT_FILE_SIZE) {
-                    builder.append("content file:[").append(contentFile).append("] greater than 10M | ");
+                    errorMessage.append("content file:[").append(contentFile).append("] greater than 10M | ");
                 }
             }
         }
-        if (builder.length() > 0) {
+
+        if (errorMessage.length() > 0) {
             result.setStatus(Status.failure);
-            result.setMessage(builder.toString());
-            System.err.println(builder);
+            result.setMessage(errorMessage.toString());
+            System.err.println(errorMessage);
         }
     }
 

--- a/src/main/java/com/tencent/bk/devops/atom/task/constant/EmailConst.java
+++ b/src/main/java/com/tencent/bk/devops/atom/task/constant/EmailConst.java
@@ -2,6 +2,8 @@ package com.tencent.bk.devops.atom.task.constant;
 
 public interface EmailConst {
 
+    String WHITE_LIST = "sendmail_whitelist";
+
     String BK_APP_CODE = "bk_app_code";
 
     String BK_APP_SECRET = "bk_app_secret";

--- a/src/main/java/com/tencent/bk/devops/atom/task/utils/NotifyUtils.java
+++ b/src/main/java/com/tencent/bk/devops/atom/task/utils/NotifyUtils.java
@@ -1,9 +1,20 @@
 package com.tencent.bk.devops.atom.task.utils;
 
+import com.google.common.collect.Sets;
+import com.tencent.bk.devops.atom.task.pojo.EmailParam;
 import com.tencent.bk.devops.atom.task.pojo.SendMailReq;
 import com.tencent.bk.devops.atom.task.pojo.SendMailResp;
 import com.tencent.bk.devops.atom.utils.http.OkHttpUtils;
 import com.tencent.bk.devops.atom.utils.json.JsonUtil;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.tencent.bk.devops.atom.task.constant.EmailConst.WHITE_LIST;
 
 public class NotifyUtils {
     private final static String EMAIL_URL = "/api/c/compapi/cmsi/send_mail/";
@@ -19,5 +30,67 @@ public class NotifyUtils {
         System.out.printf("notify post request result=%s\n", result);
 
         return JsonUtil.fromJson(result, SendMailResp.class);
+    }
+
+    public static List<String> checkReceivers(EmailParam param, StringBuilder errorMessage) {
+
+        if (StringUtils.isBlank(param.getReceivers())) {
+            errorMessage.append("| receiver cannot be empty ");
+            return Collections.emptyList();
+        }
+
+        String splitRegex = "[,;]";
+        String domainPrefix = "@";
+
+        String whiteList = param.getBkSensitiveConfInfo().get(WHITE_LIST);
+        if (whiteList.isEmpty()) { // nothing skip
+            System.err.printf("%s is not deploy! \n", WHITE_LIST);
+            return Collections.emptyList();
+        }
+        Set<String> whiteListSet = Sets.newHashSet(whiteList.split(splitRegex)).stream()
+            .filter(s -> !s.trim().isEmpty())
+            .map(s -> {
+                if (s.trim().startsWith(domainPrefix)) {
+                    return s.trim();
+                } else if (s.trim().equals("*")) {
+                    return s.trim();
+                } else {
+                    return domainPrefix + s.trim();
+                }
+            })
+            .collect(Collectors.toSet());
+
+        System.out.printf("%s deploy: %s \n", WHITE_LIST, whiteListSet);
+
+        // do not check any domain
+        if (whiteListSet.contains("*")) {
+            System.err.printf("WARNING：%s deploy: [*] allow to send to all domains!\n", WHITE_LIST);
+            return Collections.emptyList();
+        }
+
+        List<String> notInWL = new ArrayList<>();
+
+        for (
+            String receiver : param.getReceivers().
+
+            split(splitRegex)) {
+            int domainPos = receiver.lastIndexOf(domainPrefix);
+            if (domainPos > 0) { // xxx@yyy.zzz
+                // check xxx@yyy.zzz and yyy.zzz
+                if (!whiteListSet.contains(receiver) && !whiteListSet.contains(receiver.substring(domainPos))) {
+                    notInWL.add(receiver);
+                }
+            } else {
+                if (!whiteListSet.contains(receiver)) { // no domain
+                    notInWL.add(receiver);
+                }
+            }
+        }
+
+        if (!notInWL.isEmpty()) {
+            errorMessage.append(String.format("| receiver %s not in whitelist %s", notInWL, whiteListSet));
+        }
+
+        return notInWL;
     }
 }

--- a/src/test/java/com/tencent/bk/devops/atom/task/utils/NotifyUtilsTest.java
+++ b/src/test/java/com/tencent/bk/devops/atom/task/utils/NotifyUtilsTest.java
@@ -1,0 +1,111 @@
+package com.tencent.bk.devops.atom.task.utils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.tencent.bk.devops.atom.task.pojo.EmailParam;
+import junit.framework.TestCase;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static com.tencent.bk.devops.atom.task.constant.EmailConst.WHITE_LIST;
+
+public class NotifyUtilsTest extends TestCase {
+
+    public void test_domain_mix() {
+
+        String user1 = "xxx@yyy.zzz";
+        String user2NoInWL = "abc@d.e";
+        String user3 = "a@b.c";
+        String whiteList = "yyy.zzz;@b.c";
+        StringBuilder err = new StringBuilder();
+        List<String> expect = Lists.newArrayList(user2NoInWL);
+
+        List<String> notInWL = getNotInWL(";", user1, user2NoInWL, user3, whiteList, err);
+        System.out.println(err);
+        Assert.assertEquals(expect, notInWL);
+
+        err = new StringBuilder();
+        notInWL = getNotInWL(",", user1, user2NoInWL, user3, whiteList, err);
+        System.out.println(err);
+        Assert.assertEquals(expect, notInWL);
+    }
+
+    public void test_no_domain() {
+
+        String user1 = "xxx@yyy.zzz";
+        String user2NoDomain = "abc";
+        String user3NotInWL = "a@b.c";
+
+        StringBuilder err = new StringBuilder();
+        String whiteList = "yyy.zzz";
+        List<String> expect = Lists.newArrayList(user2NoDomain, user3NotInWL);
+
+        List<String> notInWL = getNotInWL(";", user1, user2NoDomain, user3NotInWL, whiteList, err);
+        System.out.println(err);
+        Assert.assertEquals(expect, notInWL);
+
+        err = new StringBuilder();
+        notInWL = getNotInWL(",", user1, user2NoDomain, user3NotInWL, whiteList, err);
+        System.out.println(err);
+        Assert.assertEquals(expect, notInWL);
+    }
+
+    public void test_all_pass() {
+
+        String user1 = "xxx@yyy.zzz";
+        String user2 = "abc";
+        String user3 = "a@b.c";
+
+        StringBuilder err = new StringBuilder();
+        String whiteListAllPass = "*";
+        List<String> empty = Collections.emptyList();
+
+        List<String> notInWL = getNotInWL(";", user1, user2, user3, whiteListAllPass, err);
+        System.out.println(err);
+        Assert.assertEquals(empty, notInWL);
+
+        err = new StringBuilder();
+        notInWL = getNotInWL(",", user1, user2, user3, whiteListAllPass, err);
+        System.out.println(err);
+        Assert.assertEquals(empty, notInWL);
+    }
+
+    public void test_all_pass_mix() {
+
+        String user1 = "xxx@yyy.zzz";
+        String user2 = "abc";
+        String user3 = "a@b.c";
+
+        StringBuilder err = new StringBuilder();
+        String whiteListAllPass = "*;yyy.zzz";
+        List<String> empty = Collections.emptyList();
+
+        List<String> notInWL = getNotInWL(";", user1, user2, user3, whiteListAllPass, err);
+        System.out.println(err);
+        Assert.assertEquals(empty, notInWL);
+
+        err = new StringBuilder();
+        notInWL = getNotInWL(",", user1, user2, user3, whiteListAllPass, err);
+        System.out.println(err);
+        Assert.assertEquals(empty, notInWL);
+    }
+
+    @NotNull
+    private static List<String> getNotInWL(String delimit, String user1,
+                                           String user2,
+                                           String user3,
+                                           String whiteList,
+                                           StringBuilder err) {
+        EmailParam param = new EmailParam();
+        param.setReceivers(String.join(delimit, user1, user2, user3));
+        HashMap<String, String> bkSensitiveConfInfo = Maps.newHashMap();
+
+        bkSensitiveConfInfo.put(WHITE_LIST, whiteList);
+        param.setBkSensitiveConfInfo(bkSensitiveConfInfo);
+        return NotifyUtils.checkReceivers(param, err);
+    }
+}

--- a/task.json
+++ b/task.json
@@ -10,6 +10,7 @@
   "input": {
     "receivers": {
       "label": "To",
+      "placeholder": "Separate multiple accounts with semicolons",
       "default": "",
       "type": "vuex-input",
       "required": false,
@@ -19,6 +20,7 @@
     },
     "ccs": {
       "label": " Cc",
+      "placeholder": "Separate multiple accounts with semicolons",
       "default": "",
       "type": "vuex-input",
       "disabled": false,


### PR DESCRIPTION
- 增加sendmail_whitelist 私有配置，用于配置允许发送的域名白名单，多个用;号分隔，输入*表示全开放, 每个邮箱域名格式为 @xxx.yyy，例如@gmail.com
fix #32 